### PR TITLE
cargo: remove license-file from the manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/devmatteini/dag"
 documentation = "https://github.com/devmatteini/dag"
 readme = "README.md"
 license = "MIT"
-license-file = "LICENSE"
 categories = ["command-line-utilities"]
 keywords = ["github", "cli"]
 


### PR DESCRIPTION
As stated in the manifest format, only one of `license` or `license-file`
is necessary and `license-file` should be only used if the package uses
a non-standard license. In the case of `dag`, MIT (SPDX) license is used
thus `license-file` can be safely removed from the manifest.

Reference: https://doc.rust-lang.org/cargo/reference/manifest.html

Signed-off-by: Orhun Parmaksız <orhunparmaksiz@gmail.com>
